### PR TITLE
Add lazy loading to images

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
         <section id="offer" class="mb-16 md:mb-24 flex justify-center fade-in-section">
             <div class="glass-effect p-8 md:p-10 w-full max-w-4xl text-gray-800 flex flex-col md:flex-row items-center gap-8">
                 <div class="md:w-1/3 w-full">
-                    <img src="fortune basmati rice biriyani special.webp" alt="বাসমতী চালের প্যাকেট" class="rounded-2xl shadow-lg w-full h-auto object-cover" onerror="this.onerror=null;this.src='https://placehold.co/400x400/FFF0F5/8A2BE2?text=চাল&font=hind-siliguri';">
+                    <img src="fortune basmati rice biriyani special.webp" loading="lazy" alt="বাসমতী চালের প্যাকেট" class="rounded-2xl shadow-lg w-full h-auto object-cover" onerror="this.onerror=null;this.src='https://placehold.co/400x400/FFF0F5/8A2BE2?text=চাল&font=hind-siliguri';">
                 </div>
                 <div class="md:w-2/3 w-full text-center md:text-left">
                     <h2 class="text-3xl font-bold mb-4">আপনার সকল সমস্যার সমাধান আমাদের প্রিমিয়াম বাসমতী চালে!</h2>
@@ -220,8 +220,8 @@
         <section id="reviews" class="mb-16 md:mb-24 fade-in-section">
             <h2 class="text-3xl md:text-4xl font-bold text-center mb-12 text-gray-800">দেখুন আমাদের সন্তুষ্ট গ্রাহকরা কী বলছেন!</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12">
-                <div class="glass-effect p-4 rounded-2xl transform hover:scale-105 transition-transform duration-300"><img src="cr1.jpg" alt="কাস্টমার রিভিউ ১" class="rounded-xl w-full h-auto object-cover" onerror="this.onerror=null;this.src='https://placehold.co/600x800/FFF0F5/8A2BE2?text=Review+1&font=hind-siliguri';"></div>
-                <div class="glass-effect p-4 rounded-2xl transform hover:scale-105 transition-transform duration-300"><img src="cr2.jpg" alt="কাস্টমার রিভিউ ২" class="rounded-xl w-full h-auto object-cover" onerror="this.onerror=null;this.src='https://placehold.co/600x800/FFF0F5/8A2BE2?text=Review+2&font=hind-siliguri';"></div>
+                <div class="glass-effect p-4 rounded-2xl transform hover:scale-105 transition-transform duration-300"><img src="cr1.jpg" loading="lazy" alt="কাস্টমার রিভিউ ১" class="rounded-xl w-full h-auto object-cover" onerror="this.onerror=null;this.src='https://placehold.co/600x800/FFF0F5/8A2BE2?text=Review+1&font=hind-siliguri';"></div>
+                <div class="glass-effect p-4 rounded-2xl transform hover:scale-105 transition-transform duration-300"><img src="cr2.jpg" loading="lazy" alt="কাস্টমার রিভিউ ২" class="rounded-xl w-full h-auto object-cover" onerror="this.onerror=null;this.src='https://placehold.co/600x800/FFF0F5/8A2BE2?text=Review+2&font=hind-siliguri';"></div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Lazily load the main product photo
- Lazily load customer review images

## Testing
- `python3 - <<'PY'
from playwright.sync_api import sync_playwright
p = sync_playwright().start()
browser = p.chromium.launch()
page = browser.new_page()
page.goto('file:///workspace/Online-bazar-barguna/index.html')
page.wait_for_load_state('load')
page.evaluate('window.scrollTo(0, document.body.scrollHeight)')
page.wait_for_timeout(1000)
imgs = page.query_selector_all('img')
for img in imgs:
    src = img.get_attribute('src')
    nw = img.evaluate('el => el.naturalWidth')
    print(src, nw)
browser.close()
p.stop()
PY`

------
https://chatgpt.com/codex/tasks/task_b_689f1fb25a44832a9492a893def8a5c7